### PR TITLE
Fix TS not narrowing down the type of Mutation<EntityType>

### DIFF
--- a/domain/actionUtils.ts
+++ b/domain/actionUtils.ts
@@ -1,13 +1,10 @@
 import { ActionSpace } from "./entity/ActionSpace";
 import { Player } from "./entity/Player";
-import { EntityType, Mutation } from "./entity/Mutation";
+import { EntityMutation } from "./entity/Mutation";
 import { Resources } from "./entity/Resources";
 
 export namespace ActionUtils {
-    export function bookActionSpace(
-        actionSpace: ActionSpace,
-        player: Player
-    ): Mutation<EntityType>[] {
+    export function bookActionSpace(actionSpace: ActionSpace, player: Player): EntityMutation[] {
         const dwarf = player.getFirstAvailableDwarf();
         return [
             { original: dwarf, diff: { isAvailable: false } },
@@ -15,10 +12,7 @@ export namespace ActionUtils {
         ];
     }
 
-    export function takeResources(
-        actionSpace: ActionSpace,
-        player: Player
-    ): Mutation<EntityType>[] {
+    export function takeResources(actionSpace: ActionSpace, player: Player): EntityMutation[] {
         return [
             { original: actionSpace, diff: { resources: new Resources() } },
             { original: player, diff: { resources: player.resources.add(actionSpace.resources) } },

--- a/domain/entity/ActionSpace.ts
+++ b/domain/entity/ActionSpace.ts
@@ -1,5 +1,5 @@
 import { Dwarf, PlayerId } from "./Player";
-import { EntityType, Mutation } from "./Mutation";
+import { EntityMutation } from "./Mutation";
 import { Game } from "./Game";
 import { Resources } from "./Resources";
 
@@ -23,7 +23,7 @@ export enum ActionSpaceId {
     GATHER_WOOD = "gather_wood",
 }
 
-export type Action = (game: Game, playerId: PlayerId) => Mutation<EntityType>[];
+export type Action = (game: Game, playerId: PlayerId) => EntityMutation[];
 
 export type Replenishment = {
     ifEmpty: Resources;

--- a/domain/entity/Mutation.ts
+++ b/domain/entity/Mutation.ts
@@ -1,15 +1,25 @@
 import { Dwarf, Player } from "./Player";
 import { ActionSpace } from "./ActionSpace";
 
-export type Mutation<T extends EntityType> = {
+export type EntityType = Player | Dwarf | ActionSpace;
+
+type Mutation<T> = {
     original: T;
     diff: Partial<T>;
 };
+
+/*
+  Note TS: EntityMutation is equivalent to Mutation<Player> | Mutation<Dwarf> | ...
+
+  Mutation<EntityPlayer> is not satisfying because it doesn't narrow down the type of T to Player, Dwarf & co
+  It checks that both `original` and `diff` are respectively based from any EntityType
+  but not that they are based from the same entity subtype
+ */
+type DiscriminateUnion<T> = T extends any ? Mutation<T> : never;
+export type EntityMutation = DiscriminateUnion<EntityType>;
 
 export function isMutationOfType<T extends EntityType>(classType: { new (): T }) {
     return function (mutation: Mutation<EntityType>): mutation is Mutation<T> {
         return mutation.original instanceof classType;
     };
 }
-
-export type EntityType = Player | Dwarf | ActionSpace;

--- a/domain/gatherWood.ts
+++ b/domain/gatherWood.ts
@@ -1,5 +1,5 @@
 import { Game } from "./entity/Game";
-import { EntityType, Mutation } from "./entity/Mutation";
+import { EntityMutation } from "./entity/Mutation";
 import { PlayerId } from "./entity/Player";
 import { ActionSpace, ActionSpaceId } from "./entity/ActionSpace";
 import { Resources, ResourceType } from "./entity/Resources";
@@ -11,7 +11,7 @@ export namespace GatherWood {
         ifNotEmpty: new Resources([[ResourceType.WOOD, 1]]),
     };
 
-    export function execute(game: Game, playerId: PlayerId): Mutation<EntityType>[] {
+    export function execute(game: Game, playerId: PlayerId): EntityMutation[] {
         const actionSpaceId = ActionSpaceId.GATHER_WOOD;
         const player = game.getPlayer(playerId);
         const actionSpace = game.actionBoard.getActionSpace(actionSpaceId);

--- a/domain/testUtils.ts
+++ b/domain/testUtils.ts
@@ -1,4 +1,4 @@
-import { EntityType, isMutationOfType, Mutation } from "./entity/Mutation";
+import { EntityMutation, isMutationOfType } from "./entity/Mutation";
 import { expect } from "chai";
 import { buildInitialGame } from "./initializeGame";
 import { Action, ActionSpace } from "./entity/ActionSpace";
@@ -35,12 +35,12 @@ export function buildBaseObjects() {
 }
 
 export function expectMutationsOfType<T extends EntityType>(
-    mutations: Mutation<EntityType>[],
+    mutations: EntityMutation[],
     classType: { new (...arg: any): T }
 ) {
     const mutationsT = mutations.filter(isMutationOfType(classType));
     return {
-        toVerifyOnce: (check: (mutation: Mutation<T>) => boolean) => {
+        toVerifyOnce: (check: (mutation: EntityMutation) => boolean) => {
             expect(mutationsT.filter((mutation) => check(mutation))).to.have.lengthOf(1);
         },
     };


### PR DESCRIPTION
We had an issue with `Mutation<EntityPlayer>`: it didn't checked that both `original` and `diff` on the mutation were based from the same subtype

See https://github.com/mdallongeville/caverna/commit/8a7939362e72f22c4a7ec5fb12c757ff92147c45#diff-10d4755ba1de3f9e78ab60ae49a8945dbfa2233a7e9c3516b1030f52f0515269R11 for details