### PR TITLE
Exclude Mutation<EntityType> from the type as it causes some issues

### DIFF
--- a/domain/actionUtils.ts
+++ b/domain/actionUtils.ts
@@ -1,10 +1,13 @@
 import { ActionSpace } from "./entity/ActionSpace";
 import { Player } from "./entity/Player";
-import { EntityMutation } from "./entity/Mutation";
+import { EntityMutation, EntityType } from "./entity/Mutation";
 import { Resources } from "./entity/Resources";
 
 export namespace ActionUtils {
-    export function bookActionSpace(actionSpace: ActionSpace, player: Player): EntityMutation[] {
+    export function bookActionSpace(
+        actionSpace: ActionSpace,
+        player: Player
+    ): EntityMutation<EntityType>[] {
         const dwarf = player.getFirstAvailableDwarf();
         return [
             { original: dwarf, diff: { isAvailable: false } },
@@ -12,7 +15,10 @@ export namespace ActionUtils {
         ];
     }
 
-    export function takeResources(actionSpace: ActionSpace, player: Player): EntityMutation[] {
+    export function takeResources(
+        actionSpace: ActionSpace,
+        player: Player
+    ): EntityMutation<EntityType>[] {
         return [
             { original: actionSpace, diff: { resources: new Resources() } },
             { original: player, diff: { resources: player.resources.add(actionSpace.resources) } },

--- a/domain/entity/ActionSpace.ts
+++ b/domain/entity/ActionSpace.ts
@@ -1,5 +1,5 @@
 import { Dwarf, PlayerId } from "./Player";
-import { EntityMutation } from "./Mutation";
+import { EntityMutation, EntityType } from "./Mutation";
 import { Game } from "./Game";
 import { Resources } from "./Resources";
 
@@ -23,7 +23,7 @@ export enum ActionSpaceId {
     GATHER_WOOD = "gather_wood",
 }
 
-export type Action = (game: Game, playerId: PlayerId) => EntityMutation[];
+export type Action = (game: Game, playerId: PlayerId) => EntityMutation<EntityType>[];
 
 export type Replenishment = {
     ifEmpty: Resources;

--- a/domain/entity/Mutation.ts
+++ b/domain/entity/Mutation.ts
@@ -9,17 +9,29 @@ type Mutation<T> = {
 };
 
 /*
-  Note TS: EntityMutation is equivalent to Mutation<Player> | Mutation<Dwarf> | ...
+  Note TS:
 
-  Mutation<EntityPlayer> is not satisfying because it doesn't narrow down the type of T to Player, Dwarf & co
-  It checks that both `original` and `diff` are respectively based from any EntityType
-  but not that they are based from the same entity subtype
+  Mutation<EntityPlayer> was not satisfying because it doesn't narrow down the type of T to Player, Dwarf & co. It checks
+  that both `original` and `diff` are respectively based from any EntityType but not that they are based from the same
+  entity subtype
+
+  We would rather be interested in "Mutation<Player> | Mutation<Dwarf> | ..." so we created DiscriminateUnion<EntityType>
+  (that is equivalent to that) to replace Mutation<EntityType>
+
+  The problem is that in the type guard "mutation is Mutation<T>", the type predicate's type (Mutation<T>)
+  must be assignable to its parameter's type (Mutation<Player> | Mutation<Dwarf> | ...). And it doesn't work when T is
+  equal to EntityType as Mutation<EntityType> is not included in (Mutation<Player> | Mutation<Dwarf> | ...) for the
+  reasons explained previously.
+
+  To fix that, we want to explicitly remove the case Mutation<EntityType>. We achieved that by creating a new type
+  EntityMutation<T> that is an intersection of Mutation<T> and DiscriminateUnion<EntityType>. And that way, everything
+  works ;)
  */
 type DiscriminateUnion<T> = T extends any ? Mutation<T> : never;
-export type EntityMutation = DiscriminateUnion<EntityType>;
+export type EntityMutation<T> = DiscriminateUnion<EntityType> & Mutation<T>;
 
 export function isMutationOfType<T extends EntityType>(classType: { new (): T }) {
-    return function (mutation: Mutation<EntityType>): mutation is Mutation<T> {
+    return function (mutation: EntityMutation<EntityType>): mutation is EntityMutation<T> {
         return mutation.original instanceof classType;
     };
 }

--- a/domain/entity/Mutation.ts
+++ b/domain/entity/Mutation.ts
@@ -8,26 +8,13 @@ type Mutation<T> = {
     diff: Partial<T>;
 };
 
-/*
-  Note TS:
-
-  Mutation<EntityPlayer> was not satisfying because it doesn't narrow down the type of T to Player, Dwarf & co. It checks
-  that both `original` and `diff` are respectively based from any EntityType but not that they are based from the same
-  entity subtype
-
-  We would rather be interested in "Mutation<Player> | Mutation<Dwarf> | ..." so we created DiscriminateUnion<EntityType>
-  (that is equivalent to that) to replace Mutation<EntityType>
-
-  The problem is that in the type guard "mutation is Mutation<T>", the type predicate's type (Mutation<T>)
-  must be assignable to its parameter's type (Mutation<Player> | Mutation<Dwarf> | ...). And it doesn't work when T is
-  equal to EntityType as Mutation<EntityType> is not included in (Mutation<Player> | Mutation<Dwarf> | ...) for the
-  reasons explained previously.
-
-  To fix that, we want to explicitly remove the case Mutation<EntityType>. We achieved that by creating a new type
-  EntityMutation<T> that is an intersection of Mutation<T> and DiscriminateUnion<EntityType>. And that way, everything
-  works ;)
- */
+// DiscriminateUnion<EntityType> is equivalent to Mutation<Player> | Mutation<Dwarf> | ...
+// It doesn't include the type Mutation<EntityType> that allows "original" and "diff" attributes of different EntityType
 type DiscriminateUnion<T> = T extends any ? Mutation<T> : never;
+
+// The problem is that Mutation<T> is not included in DiscriminateUnion<EntityType> because of Mutation<EntityType>
+// and so we can't use the type guard below to narrow the type of Mutation<T> (see https://github.com/microsoft/TypeScript/issues/24935)
+// To fix that, we create a new type with an intersection to exclude Mutation<EntityType>
 export type EntityMutation<T> = DiscriminateUnion<EntityType> & Mutation<T>;
 
 export function isMutationOfType<T extends EntityType>(classType: { new (): T }) {

--- a/domain/gatherWood.ts
+++ b/domain/gatherWood.ts
@@ -1,5 +1,5 @@
 import { Game } from "./entity/Game";
-import { EntityMutation } from "./entity/Mutation";
+import { EntityMutation, EntityType } from "./entity/Mutation";
 import { PlayerId } from "./entity/Player";
 import { ActionSpace, ActionSpaceId } from "./entity/ActionSpace";
 import { Resources, ResourceType } from "./entity/Resources";
@@ -11,7 +11,7 @@ export namespace GatherWood {
         ifNotEmpty: new Resources([[ResourceType.WOOD, 1]]),
     };
 
-    export function execute(game: Game, playerId: PlayerId): EntityMutation[] {
+    export function execute(game: Game, playerId: PlayerId): EntityMutation<EntityType>[] {
         const actionSpaceId = ActionSpaceId.GATHER_WOOD;
         const player = game.getPlayer(playerId);
         const actionSpace = game.actionBoard.getActionSpace(actionSpaceId);

--- a/domain/testUtils.ts
+++ b/domain/testUtils.ts
@@ -1,4 +1,4 @@
-import { EntityMutation, isMutationOfType } from "./entity/Mutation";
+import { EntityMutation, EntityType, isMutationOfType } from "./entity/Mutation";
 import { expect } from "chai";
 import { buildInitialGame } from "./initializeGame";
 import { Action, ActionSpace } from "./entity/ActionSpace";
@@ -35,12 +35,12 @@ export function buildBaseObjects() {
 }
 
 export function expectMutationsOfType<T extends EntityType>(
-    mutations: EntityMutation[],
+    mutations: EntityMutation<EntityType>[],
     classType: { new (...arg: any): T }
 ) {
     const mutationsT = mutations.filter(isMutationOfType(classType));
     return {
-        toVerifyOnce: (check: (mutation: EntityMutation) => boolean) => {
+        toVerifyOnce: (check: (mutation: EntityMutation<T>) => boolean) => {
             expect(mutationsT.filter((mutation) => check(mutation))).to.have.lengthOf(1);
         },
     };


### PR DESCRIPTION
Suite de https://github.com/mdallongeville/caverna/pull/3

`Mutation<EntityPlayer>` was not satisfying because it doesn't narrow down the type of `T` to `Player`, `Dwarf` & co. It checks that both `original` and `diff` are respectively based from any `EntityType` but not that they are based from the same entity subtype

We would rather be interested in `Mutation<Player> | Mutation<Dwarf> | ...` so we created `DiscriminateUnion<EntityType>` (that is equivalent to that) to replace `Mutation<EntityType>`

The problem is that in the type guard "mutation is `Mutation<T>`", the type predicate's type (`Mutation<T>`) must be assignable to its parameter's type (`Mutation<Player> | Mutation<Dwarf> | ...`). And it doesn't work when T is equal to `EntityType` as `Mutation<EntityType>` is not included in (`Mutation<Player> | Mutation<Dwarf> | ...`) for the reasons explained previously.

To fix that, we want to explicitly remove the case `Mutation<EntityType>`. We achieved that by creating a new type `EntityMutation<T>` that is an intersection of `Mutation<T>` and `DiscriminateUnion<EntityType>`. And that way, everything works ;)